### PR TITLE
fix: ensure that e2e projects build on 7.x

### DIFF
--- a/REPO.bazel
+++ b/REPO.bazel
@@ -1,7 +1,0 @@
-"""Global repository settings.
-
-See https://bazel.build/rules/lib/globals/repo
-"""
-ignore_directories([
-    "**/node_modules",
-])

--- a/e2e/bzlmod/.bazelrc
+++ b/e2e/bzlmod/.bazelrc
@@ -1,1 +1,10 @@
 import %workspace%/../../tools/preset.bazelrc
+
+# Starting in bazel 7.0, workspaces can be disabled in preparation for being
+# completely removed by bazel 9.0. This project requires bzlmod and to ensure
+# corrrect CI behavior, we ensure workspaces are disabled for all bazel
+# commands.
+#
+# See https://blog.bazel.build/2023/07/24/whats-new-with-bzlmod.html#high-level-roadmap-for-the-future
+common --enable_bzlmod
+common --noenable_workspace

--- a/e2e/yoga_server/.bazelrc
+++ b/e2e/yoga_server/.bazelrc
@@ -4,6 +4,15 @@ common --@aspect_rules_ts//ts:skipLibCheck=always
 # use `tsc` for transpiling, even though it's slow.
 common --@aspect_rules_ts//ts:default_to_tsc_transpiler
 
+# Starting in bazel 7.0, workspaces can be disabled in preparation for being
+# completely removed by bazel 9.0. This project requires bzlmod and to ensure
+# corrrect CI behavior, we ensure workspaces are disabled for all bazel
+# commands.
+#
+# See https://blog.bazel.build/2023/07/24/whats-new-with-bzlmod.html#high-level-roadmap-for-the-future
+common --enable_bzlmod
+common --noenable_workspace
+
 # Load any settings & overrides specific to the current user from `.aspect/bazelrc/user.bazelrc`.
 # This file should appear in `.gitignore` so that settings are not shared with team members. This
 # should be last statement in this config so the user configuration is able to overwrite flags from

--- a/e2e/yoga_server/.bazelversion
+++ b/e2e/yoga_server/.bazelversion
@@ -1,0 +1,1 @@
+../../.bazelversion


### PR DESCRIPTION
See conversation on https://github.com/bazelbuild/bazel-central-registry/pull/6034 and https://blog.bazel.build/2023/07/24/whats-new-with-bzlmod.html#high-level-roadmap-for-the-future